### PR TITLE
Faster OTC font loading

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -14,11 +14,13 @@
 //!
 //! To open the font referenced by a handle, use a loader.
 
+use std::any::Any;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::error::FontLoadingError;
 use crate::font::Font;
+use crate::loader::Loader;
 
 /// Encapsulates the information needed to locate and open a font.
 ///
@@ -45,6 +47,11 @@ pub enum Handle {
         /// If the memory consists of a single font, this value will be 0.
         font_index: u32,
     },
+    /// An already-loaded font.
+    Native {
+        /// Type-erased font storage. Use [`Self::from_native`] to retrieve the font object.
+        inner: Arc<dyn Any + Send + Sync>,
+    },
 }
 
 impl Handle {
@@ -66,6 +73,22 @@ impl Handle {
         Handle::Memory { bytes, font_index }
     }
 
+    /// Creates a new handle from a system handle.
+    pub fn from_native<T: Loader>(inner: &T) -> Self {
+        Self::Native {
+            inner: Arc::new(inner.native_font()),
+        }
+    }
+    /// Retrieves a handle to the font object.
+    ///
+    /// May return None if inner object is not of type `T` or if this handle does not contain a native font object.
+    pub fn native_as<T: 'static + Send + Sync>(&self) -> Option<&T> {
+        if let Self::Native { inner } = self {
+            inner.downcast_ref()
+        } else {
+            None
+        }
+    }
     /// A convenience method to load this handle with the default loader, producing a Font.
     #[inline]
     pub fn load(&self) -> Result<Font, FontLoadingError> {

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -50,7 +50,7 @@ pub enum Handle {
     /// An already-loaded font.
     Native {
         /// Type-erased font storage. Use [`Self::from_native`] to retrieve the font object.
-        inner: Arc<dyn Any + Send + Sync>,
+        inner: Arc<dyn Any + Sync + Send>,
     },
 }
 
@@ -74,7 +74,10 @@ impl Handle {
     }
 
     /// Creates a new handle from a system handle.
-    pub fn from_native<T: Loader>(inner: &T) -> Self {
+    pub fn from_native<T: Loader>(inner: &T) -> Self
+    where
+        T::NativeFont: Sync + Send,
+    {
         Self::Native {
             inner: Arc::new(inner.native_font()),
         }
@@ -82,7 +85,7 @@ impl Handle {
     /// Retrieves a handle to the font object.
     ///
     /// May return None if inner object is not of type `T` or if this handle does not contain a native font object.
-    pub fn native_as<T: 'static + Send + Sync>(&self) -> Option<&T> {
+    pub fn native_as<T: 'static>(&self) -> Option<&T> {
         if let Self::Native { inner } = self {
             inner.downcast_ref()
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,5 +144,5 @@ pub mod source;
 #[cfg(feature = "source")]
 pub mod sources;
 
-mod matching;
+pub mod matching;
 mod utils;

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -15,7 +15,6 @@ use log::warn;
 use pathfinder_geometry::rect::{RectF, RectI};
 use pathfinder_geometry::transform2d::Transform2F;
 use pathfinder_geometry::vector::Vector2F;
-use std::convert::TryFrom;
 use std::sync::Arc;
 
 use crate::canvas::{Canvas, RasterizationOptions};

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -15,6 +15,7 @@ use log::warn;
 use pathfinder_geometry::rect::{RectF, RectI};
 use pathfinder_geometry::transform2d::Transform2F;
 use pathfinder_geometry::vector::Vector2F;
+use std::convert::TryFrom;
 use std::sync::Arc;
 
 use crate::canvas::{Canvas, RasterizationOptions};
@@ -35,7 +36,7 @@ use std::path::Path;
 /// fonts.
 pub trait Loader: Clone + Sized {
     /// The handle that the API natively uses to represent a font.
-    type NativeFont;
+    type NativeFont: 'static + Send + Sync;
 
     /// Loads a font from raw font data (the contents of a `.ttf`/`.otf`/etc. file).
     ///
@@ -63,22 +64,23 @@ pub trait Loader: Clone + Sized {
     }
 
     /// Creates a font from a native API handle.
-    unsafe fn from_native_font(native_font: Self::NativeFont) -> Self;
+    unsafe fn from_native_font(native_font: &Self::NativeFont) -> Self;
 
     /// Loads the font pointed to by a handle.
     fn from_handle(handle: &Handle) -> Result<Self, FontLoadingError> {
-        match *handle {
-            Handle::Memory {
-                ref bytes,
-                font_index,
-            } => Self::from_bytes((*bytes).clone(), font_index),
+        match handle {
+            Handle::Memory { bytes, font_index } => Self::from_bytes((*bytes).clone(), *font_index),
             #[cfg(not(target_arch = "wasm32"))]
-            Handle::Path {
-                ref path,
-                font_index,
-            } => Self::from_path(path, font_index),
+            Handle::Path { path, font_index } => Self::from_path(path, *font_index),
             #[cfg(target_arch = "wasm32")]
             Handle::Path { .. } => Err(FontLoadingError::NoFilesystem),
+            Handle::Native { .. } => {
+                if let Some(native) = handle.native_as::<Self::NativeFont>() {
+                    unsafe { Ok(Self::from_native_font(native)) }
+                } else {
+                    Err(FontLoadingError::UnknownFormat)
+                }
+            }
         }
     }
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -35,7 +35,7 @@ use std::path::Path;
 /// fonts.
 pub trait Loader: Clone + Sized {
     /// The handle that the API natively uses to represent a font.
-    type NativeFont: 'static + Send + Sync;
+    type NativeFont: 'static;
 
     /// Loads a font from raw font data (the contents of a `.ttf`/`.otf`/etc. file).
     ///

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -122,35 +122,14 @@ impl Font {
     }
 
     /// Creates a font from a native API handle.
-    pub unsafe fn from_native_font(core_text_font: NativeFont) -> Font {
-        Font::from_core_text_font_no_path(core_text_font)
+    pub unsafe fn from_native_font(core_text_font: &NativeFont) -> Font {
+        Font::from_core_text_font_no_path(core_text_font.clone())
     }
     /// Creates a font from a native API handle, without performing a lookup on the disk.
     pub unsafe fn from_core_text_font_no_path(core_text_font: NativeFont) -> Font {
         Font {
             core_text_font,
             font_data: FontData::Unavailable,
-        }
-    }
-    unsafe fn from_core_text_font(core_text_font: NativeFont) -> Font {
-        let mut font_data = FontData::Unavailable;
-        match core_text_font.url() {
-            None => warn!("No URL found for Core Text font!"),
-            Some(url) => match url.to_path() {
-                Some(path) => match File::open(path) {
-                    Ok(ref mut file) => match utils::slurp_file(file) {
-                        Ok(data) => font_data = FontData::Memory(Arc::new(data)),
-                        Err(_) => warn!("Couldn't read file data for Core Text font!"),
-                    },
-                    Err(_) => warn!("Could not open file for Core Text font!"),
-                },
-                None => warn!("Could not convert URL from Core Text font to path!"),
-            },
-        }
-
-        Font {
-            core_text_font,
-            font_data,
         }
     }
 
@@ -637,7 +616,7 @@ impl Loader for Font {
     }
 
     #[inline]
-    unsafe fn from_native_font(native_font: Self::NativeFont) -> Self {
+    unsafe fn from_native_font(native_font: &Self::NativeFont) -> Self {
         Font::from_native_font(native_font)
     }
 

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -123,9 +123,15 @@ impl Font {
 
     /// Creates a font from a native API handle.
     pub unsafe fn from_native_font(core_text_font: NativeFont) -> Font {
-        Font::from_core_text_font(core_text_font)
+        Font::from_core_text_font_no_path(core_text_font)
     }
-
+    /// Creates a font from a native API handle, without performing a lookup on the disk.
+    pub unsafe fn from_core_text_font_no_path(core_text_font: NativeFont) -> Font {
+        Font {
+            core_text_font,
+            font_data: FontData::Unavailable,
+        }
+    }
     unsafe fn from_core_text_font(core_text_font: NativeFont) -> Font {
         let mut font_data = FontData::Unavailable;
         match core_text_font.url() {
@@ -153,7 +159,10 @@ impl Font {
     /// This function is only available on the Core Text backend.
     pub fn from_core_graphics_font(core_graphics_font: CGFont) -> Font {
         unsafe {
-            Font::from_core_text_font(core_text::font::new_from_CGFont(&core_graphics_font, 16.0))
+            Font::from_core_text_font_no_path(core_text::font::new_from_CGFont(
+                &core_graphics_font,
+                16.0,
+            ))
         }
     }
 

--- a/src/loaders/directwrite.rs
+++ b/src/loaders/directwrite.rs
@@ -61,6 +61,7 @@ const OPENTYPE_TABLE_TAG_HEAD: u32 = 0x68656164;
 
 /// DirectWrite's representation of a font.
 #[allow(missing_debug_implementations)]
+#[derive(Clone)]
 pub struct NativeFont {
     /// The native DirectWrite font object.
     pub dwrite_font: DWriteFont,

--- a/src/loaders/directwrite.rs
+++ b/src/loaders/directwrite.rs
@@ -160,7 +160,8 @@ impl Font {
 
     /// Creates a font from a native API handle.
     #[inline]
-    pub unsafe fn from_native_font(native_font: NativeFont) -> Font {
+    pub unsafe fn from_native_font(native_font: &NativeFont) -> Font {
+        let native_font = native_font.clone();
         Font {
             dwrite_font: native_font.dwrite_font,
             dwrite_font_face: native_font.dwrite_font_face,
@@ -747,7 +748,7 @@ impl Loader for Font {
     }
 
     #[inline]
-    unsafe fn from_native_font(native_font: Self::NativeFont) -> Self {
+    unsafe fn from_native_font(native_font: &Self::NativeFont) -> Self {
         Font::from_native_font(native_font)
     }
 

--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -182,9 +182,10 @@ impl Font {
     }
 
     /// Creates a font from a native API handle.
-    pub unsafe fn from_native_font(freetype_face: NativeFont) -> Font {
+    pub unsafe fn from_native_font(freetype_face: &NativeFont) -> Font {
         // We make an in-memory copy of the underlying font data. This is because the native font
         // does not necessarily hold a strong reference to the memory backing it.
+        let freetype_face = *freetype_face;
         const CHUNK_SIZE: usize = 4096;
         let mut font_data = vec![];
         loop {
@@ -1013,7 +1014,7 @@ impl Loader for Font {
     }
 
     #[inline]
-    unsafe fn from_native_font(native_font: Self::NativeFont) -> Self {
+    unsafe fn from_native_font(native_font: &Self::NativeFont) -> Self {
         Font::from_native_font(native_font)
     }
 

--- a/src/sources/core_text.rs
+++ b/src/sources/core_text.rs
@@ -154,12 +154,6 @@ fn css_stretchiness_to_core_text_width(css_stretchiness: Stretch) -> f32 {
     0.25 * core_text_loader::piecewise_linear_find_index(css_stretchiness, &Stretch::MAPPING) - 1.0
 }
 
-#[derive(Clone)]
-struct FontDataInfo {
-    data: Arc<Vec<u8>>,
-    file_type: FileType,
-}
-
 fn create_handles_from_core_text_collection(
     collection: CTFontCollection,
 ) -> Result<Vec<Handle>, SelectionError> {
@@ -169,8 +163,8 @@ fn create_handles_from_core_text_collection(
             let descriptor = descriptors.get(index).unwrap();
             let native = new_from_descriptor(&descriptor, 16.);
             let font = unsafe { Font::from_core_text_font_no_path(native.clone()) };
-            todo!();
-            //fonts.push(Handle::from(font));
+
+            fonts.push(Handle::from_native(&font));
         }
     }
     if fonts.is_empty() {

--- a/src/sources/core_text.rs
+++ b/src/sources/core_text.rs
@@ -14,6 +14,7 @@ use core_foundation::array::CFArray;
 use core_foundation::base::{CFType, TCFType};
 use core_foundation::dictionary::CFDictionary;
 use core_foundation::string::CFString;
+use core_text::font::new_from_descriptor;
 use core_text::font_collection::{self, CTFontCollection};
 use core_text::font_descriptor::{self, CTFontDescriptor};
 use core_text::font_manager;
@@ -164,57 +165,12 @@ fn create_handles_from_core_text_collection(
 ) -> Result<Vec<Handle>, SelectionError> {
     let mut fonts = vec![];
     if let Some(descriptors) = collection.get_descriptors() {
-        let mut font_data_info_cache: HashMap<PathBuf, FontDataInfo> = HashMap::new();
-
-        'outer: for index in 0..descriptors.len() {
+        for index in 0..descriptors.len() {
             let descriptor = descriptors.get(index).unwrap();
-            let font_path = descriptor.font_path().unwrap();
-
-            let data_info = if let Some(data_info) = font_data_info_cache.get(&font_path) {
-                data_info.clone()
-            } else {
-                let mut file = if let Ok(file) = File::open(&font_path) {
-                    file
-                } else {
-                    continue;
-                };
-                let data = if let Ok(data) = utils::slurp_file(&mut file) {
-                    Arc::new(data)
-                } else {
-                    continue;
-                };
-
-                let file_type = match Font::analyze_bytes(Arc::clone(&data)) {
-                    Ok(file_type) => file_type,
-                    Err(_) => continue,
-                };
-
-                let data_info = FontDataInfo { data, file_type };
-
-                font_data_info_cache.insert(font_path.clone(), data_info.clone());
-
-                data_info
-            };
-
-            match data_info.file_type {
-                FileType::Collection(font_count) => {
-                    let postscript_name = descriptor.font_name();
-                    for font_index in 0..font_count {
-                        if let Ok(font) = Font::from_bytes(Arc::clone(&data_info.data), font_index)
-                        {
-                            if let Some(font_postscript_name) = font.postscript_name() {
-                                if postscript_name == font_postscript_name {
-                                    fonts.push(Handle::from_memory(data_info.data, font_index));
-                                    continue 'outer;
-                                }
-                            }
-                        }
-                    }
-                }
-                FileType::Single => {
-                    fonts.push(Handle::from_memory(data_info.data, 0));
-                }
-            }
+            let native = new_from_descriptor(&descriptor, 16.);
+            let font = unsafe { Font::from_core_text_font_no_path(native.clone()) };
+            todo!();
+            //fonts.push(Handle::from(font));
         }
     }
     if fonts.is_empty() {

--- a/tests/select_font.rs
+++ b/tests/select_font.rs
@@ -43,6 +43,7 @@ macro_rules! match_handle {
                     font_index, $index
                 );
             }
+            Handle::Native { .. } => {}
         }
     };
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -627,18 +627,6 @@ pub fn get_font_properties() {
 
 #[cfg(feature = "source")]
 #[test]
-pub fn get_font_data() {
-    let font = SystemSource::new()
-        .select_best_match(&[FamilyName::SansSerif], &Properties::new())
-        .unwrap()
-        .load()
-        .unwrap();
-    let data = font.copy_font_data().unwrap();
-    debug_assert!(SFNT_VERSIONS.iter().any(|version| data[0..4] == *version));
-}
-
-#[cfg(feature = "source")]
-#[test]
 pub fn load_font_table() {
     let font = SystemSource::new()
         .select_best_match(&[FamilyName::SansSerif], &Properties::new())


### PR DESCRIPTION
This commit vastly simplifies the way .otc parsing is done in font-kit by initializing a font from a descriptor and not copying the buffer. It also makes `Handle` capable of storing an already loaded font, as what happens currently is that we first have a Font which we turn into a Handle (losing track of the Font that was used to create it) only to recreate a font from that same handle (and reparsing the font file in the process). Less waste is good.

I've had another stab at it over the weekend at https://github.com/osiewicz/font-kit/pull/new/improve_font_parsing_perf but changes from this PR are way smaller and make more sense IMHO. `improve_font_parsing_perf` tried to deal with issues in font-kit's implementation of otc parsing (it had an accidental O(n^2)), but it couldn't deal with the fact that font-kit had to allocate about 16Gb of memory (kid you not) to parse Iosevka file. :))))) Each 300Mb allocation took about 30ms, and we had to make 54 of those. Quick math: by allocations alone that approach couldn't get below 1.5s for parsing Iosevka, no matter how hard we tried.

Meanwhile, on this branch parsing Iosevka takes about 30ms and most of that time is spent.. well.. parsing the font I guess?
![image](https://github.com/zed-industries/font-kit/assets/24362066/c25b56f8-3eb3-42b7-ab75-c3282a7d6e17)

I want to let this code sit on Nightly a day or two before releasing it to the Preview.