### PR TITLE
fix: upgrade core-graphics to 0.25 for core-text 21.1.0 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,9 @@ features = ["dwrite", "minwindef", "sysinfoapi", "winbase", "winnt"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation = "0.10"
-core-graphics = "0.24"
-core-text = "21.0.0"
+# Upgraded to 0.25 to match core-text 21.1.0 which requires core-graphics 0.25
+core-graphics = "0.25"
+core-text = "21"
 
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 freetype-sys = "0.20"


### PR DESCRIPTION
## Summary

core-text 21.1.0 (released 2026-01-15) upgraded its core-graphics dependency from 0.24 to 0.25. This caused build failures when font-kit was used as a dependency because it still specified core-graphics 0.24, resulting in two incompatible versions of core-graphics in the dependency tree.

## Problem

The symptom was type mismatches like:
```
expected `core_graphics::font::CGFont`, found a different `core_graphics::font::CGFont`
```

This is because Rust treats types from different versions of the same crate as distinct types.

## Solution

Upgrade core-graphics from 0.24 to 0.25 to match what core-text 21.1.0 requires.

## Testing

Tested by building a project that depends on gpui-ce, which uses zed-font-kit. Build succeeds with this fix.

Fixes: https://github.com/zed-industries/zed/issues/47168